### PR TITLE
Feature/73 refactor copy password buttom

### DIFF
--- a/src/components/molecules/CopyButton/CopyButton.test.js
+++ b/src/components/molecules/CopyButton/CopyButton.test.js
@@ -19,7 +19,7 @@
  */
 
  import { render, screen, act } from '@testing-library/react';
- import LanguageSelector from './index.js';
+ import CopyButton from './index.js';
  import i18n from 'i18next';
  import {i18nConfig} from '../../../config/i18n.js';
  import {initReactI18next} from 'react-i18next';
@@ -28,23 +28,16 @@ beforeAll(() => {
     i18n.use(initReactI18next).init(i18nConfig);
 });
 
- test('Checks that the main languages are present', () => {
+ test('Checks that the element is present and with the corresponding text', () => {
     
-   render(<LanguageSelector/>);
-   const linkElementEspaniol = screen.getByText("Español");
-   const linkElementIngles = screen.getByText("English");
-   expect(linkElementEspaniol).toBeInTheDocument();
-   expect(linkElementIngles).toBeInTheDocument();
+   render(<CopyButton/>);
+   const ButtonElement = screen.getByText("Copy");
+   expect(ButtonElement).toBeInTheDocument();
  });
  
- test('It should change from one language to other', async () => {
-    render(<LanguageSelector/>);
-    const textExample = screen.getByText('Switch to:');
-    expect(textExample).toBeInTheDocument();
-    const linkElementEspaniol = screen.getByText("Español");
-    act(() => {
-        linkElementEspaniol.click();
-    });
-    expect(await screen.findByText("Cambiar a:")).toBeInTheDocument();
+ test('It should have a padding-left style to have space', () => {
+    render(<CopyButton/>);
+    const ButtonElement = screen.getByTestId("button-copy-element");
+    expect(ButtonElement).toHaveStyle('padding-left: 0.7rem');
  });
  

--- a/src/components/molecules/CopyButton/index.js
+++ b/src/components/molecules/CopyButton/index.js
@@ -36,7 +36,7 @@ const MoleculesButtonCopy = ({value}) => {
     };
 
     return (
-        <ButtonCopy>
+        <ButtonCopy data-testid="button-copy-element">
             <Button
                 label={t("common.Copy")}
                 onClick={copyHandler}

--- a/src/components/molecules/CopyButton/index.js
+++ b/src/components/molecules/CopyButton/index.js
@@ -1,0 +1,55 @@
+/** 
+ * This file is part of Passager Password Manager.
+ * https://github.com/oegea/passager-password-manager
+ * 
+ * Copyright (C) 2022 Oriol Egea Carvajal
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Third party dependencies
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import Button from '../../atoms/Button/index.js';
+
+const ButtonCopy = styled.div`
+    padding-left: 0.7rem;
+`;
+
+const MoleculesButtonCopy = ({value}) => {
+    const { t } = useTranslation();
+
+    const copyHandler = () => {
+        navigator.clipboard.writeText(value);
+    };
+
+    return (
+        <ButtonCopy>
+            <Button
+                label={t("common.Copy")}
+                onClick={copyHandler}
+                color="black"
+                backgroundColor="white"
+            />
+        </ButtonCopy>
+    );
+}
+
+MoleculesButtonCopy.displayName = 'MoleculesButtonCopy';
+MoleculesButtonCopy.propTypes = {
+    value: PropTypes.string
+}
+
+export default MoleculesButtonCopy;

--- a/src/components/organisms/PasswordFormDialog/index.js
+++ b/src/components/organisms/PasswordFormDialog/index.js
@@ -33,6 +33,7 @@ import InputLabel from "../../atoms/InputLabel/index.js";
 import SectionTitle from "../../molecules/SectionTitle/index.js";
 // Hooks
 import useDialogConfirmation from "../../../hooks/useDialogConfirmation/index.js";
+import MoleculesButtonCopy from "../../molecules/CopyButton/index.js";
 
 const DEFAULT_VALUES = {
   name: "",
@@ -106,10 +107,6 @@ const PasswordFormDialog = ({
     }
   };
 
-  const copyHandler = () => {
-    navigator.clipboard.writeText(state.password.value);
-  };
-
   useDialogConfirmation(onClose, beforeSave);
 
   return (
@@ -168,14 +165,17 @@ const PasswordFormDialog = ({
         <InputLabel htmlFor="username">
           {t("passwordFormDialog.Username")}
         </InputLabel>
-        <Input
-          autoComplete="off"
-          defaultValue={state.username.value}
-          id="username"
-          type="text"
-          placeholder={t("passwordFormDialog.usernameExample")}
-          onChange={(e) => onChangeHandler(e, "username")}
-        />
+        <div style={{display:'flex'}}>
+          <Input
+            autoComplete="off"
+            defaultValue={state.username.value}
+            id="username"
+            type="text"
+            placeholder={t("passwordFormDialog.usernameExample")}
+            onChange={(e) => onChangeHandler(e, "username")}
+          />
+          <MoleculesButtonCopy value={state.username.value} />
+        </div>
         {state.username.error.length > 0 && (
           <span style={{ color: "red" }}>{state.username.error}</span>
         )}
@@ -194,16 +194,11 @@ const PasswordFormDialog = ({
             placeholder={t("passwordFormDialog.Your secret password")}
             onChange={(e) => onChangeHandler(e, "password")}
           />
-          <Button
-            label={t("common.Copy")}
-            onClick={copyHandler}
-            color="black"
-            backgroundColor="white"
-          />
-          {state.password.error.length > 0 && (
+          <MoleculesButtonCopy value={state.password.value} />
+        </div>
+        {state.password.error.length > 0 && (
             <span style={{ color: "red" }}>{state.password.error}</span>
           )}
-        </div>
       </InputWrapper>
 
       <ButtonWrapper>


### PR DESCRIPTION
# Pull Request

## 💬 Context
Fixed a new component integrated, getting it to its own component file, and giving it corresponding styles.

#73 

## 👩🏼‍🎨 Changes
- Fixed the div flex in the PasswordFormDialog, so the error is shown down of the input and not at the side
- Created a new molecule component, with the copy button
- Gave the copy button a padding-left attribute
- create some simple unit tests, as the copy action per se is not testeable in rtl, it was left out.

## 💬 Other comments

Optionally, any other relevant comments can be included here.

## 📸 Images

![imagen](https://user-images.githubusercontent.com/29789445/193409714-5ab00675-be4a-4f09-bcd0-313b6cb8ab16.png)
![imagen](https://user-images.githubusercontent.com/29789445/193409718-d153167d-0928-443b-8ec8-5889bd440891.png)

