### PR TITLE
feat: add optional prop for description to confirmation dialog organism

### DIFF
--- a/src/components/atoms/Description/index.js
+++ b/src/components/atoms/Description/index.js
@@ -1,0 +1,43 @@
+/** 
+ * This file is part of Passager Password Manager.
+ * https://github.com/oegea/passager-password-manager
+ * 
+ * Copyright (C) 2022 Oriol Egea Carvajal
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Third party dependencies
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Description = styled.div`
+    margin-bottom: ${props => props.marginBottom};
+    margin-top: ${props => props.marginTop};
+    ${(props => props.onClick ? 'cursor: pointer' : '')}
+`;
+
+const AtomDescription = ({ children, marginBottom = '0px', marginTop = '0px', onClick = undefined }) => {
+    return <Description marginBottom={marginBottom} marginTop={marginTop} onClick={onClick}>{children}</Description>
+}
+
+AtomDescription.displayName = 'AtomDescription';
+AtomDescription.propTypes = {
+    children: PropTypes.node,
+    marginBottom: PropTypes.string,
+    marginTop: PropTypes.string,
+    onClick: PropTypes.func
+};
+
+export default AtomDescription;

--- a/src/components/organisms/ConfirmationDialog/index.js
+++ b/src/components/organisms/ConfirmationDialog/index.js
@@ -24,20 +24,23 @@ import PropTypes from 'prop-types';
 // Atoms
 import Button from '../../atoms/Button/index.js';
 import ButtonWrapper from '../../atoms/Dialog/DialogButtonWrapper.js';
+import Description from '../../atoms/Description/index.js';
 import Dialog from '../../atoms/Dialog/Dialog.js';
 import Title from '../../atoms/Title/index.js';
 // Hooks
 import useDialogConfirmation from '../../../hooks/useDialogConfirmation/index.js';
 import useTranslation from '../../../hooks/useTranslation/index.js';
 
-const ConfirmationDialog = ({onAccept, closeDialog}) => {
+const ConfirmationDialog = ({onAccept, closeDialog, description = ''}) => {
     const {t} = useTranslation();
     useDialogConfirmation(closeDialog, onAccept);
 
     return (
         <Dialog onClose={() => closeDialog()}>
-            <Title marginBottom='75px'>{t('confirmationDialog.Are you sure you want to proceed?')}</Title>
-            
+            <Title marginBottom='25px'>{t('confirmationDialog.Are you sure you want to proceed?')}</Title>
+            {description && (
+                <Description>{description}</Description>
+            )}
             <ButtonWrapper>
                 <Button label={t('common.Cancel')} onClick={() => closeDialog()} color="black" backgroundColor="white"/>
                 <Button label={t('common.Continue')} onClick={() => onAccept()} color="black" backgroundColor="white"/>
@@ -50,6 +53,7 @@ ConfirmationDialog.displayName = 'ConfirmationDialog';
 ConfirmationDialog.propTypes = {
     onAccept: PropTypes.func,
     closeDialog: PropTypes.func,
+    description: PropTypes.string
 }
 
 export default ConfirmationDialog;


### PR DESCRIPTION
# Pull Request
#49 
## 💬 Context

 Confirmation dialog component to be able to receive a description, and display it inside the dialog in order to display a description of which action is being confirmed

## 👩🏼‍🎨 Changes

Please detail which changes are introduced within this PR.

- Created new Atom Component for Description

- Added prop description prop for Confirmation Dialog

## 📸 Images
<img width="443" alt="Screen Shot 2022-09-30 at 10 56 25 PM" src="https://user-images.githubusercontent.com/24661071/193419914-fc855798-ba22-42be-943b-7f6bc039178e.png">

