### PR TITLE
ADD: editMode prop to handle autoFocus

### DIFF
--- a/src/components/organisms/DocumentsListRightPanel/index.js
+++ b/src/components/organisms/DocumentsListRightPanel/index.js
@@ -266,6 +266,7 @@ const DocumentsListRightPanel = ({
                     onSave={(password, passwordId) =>
                         onEditPassword(password, passwordId)
                     }
+                    editMode
                 />
             )}
             {deleteState.showDialog && (

--- a/src/components/organisms/PasswordFormDialog/index.js
+++ b/src/components/organisms/PasswordFormDialog/index.js
@@ -47,6 +47,7 @@ const PasswordFormDialog = ({
     onClose,
     onDelete,
     onSave,
+    editMode = false,
 }) => {
     const { name, url, username, password } = defaultValues;
 
@@ -132,7 +133,7 @@ const PasswordFormDialog = ({
                 </InputLabel>
                 <Input
                     autoComplete="off"
-                    autoFocus
+                    autoFocus={!editMode}
                     defaultValue={state.name.value}
                     id="name"
                     onChange={(e) => onChangeHandler(e, 'name')}
@@ -227,6 +228,7 @@ PasswordFormDialog.propTypes = {
     onClose: PropTypes.func,
     onDelete: PropTypes.func,
     onSave: PropTypes.func,
+    editMode: PropTypes.boolean,
 };
 
 export default PasswordFormDialog;


### PR DESCRIPTION
# Pull Request

## 💬 Context

Please describe the reason to submit this PR.

Closes #87 

## 👩🏼‍🎨 Changes

I added a new prop called `editMode` so we can use it as a state when the PasswordFormDialog is being edited.


https://user-images.githubusercontent.com/1775881/193573282-e5f67fe1-318c-452b-8bf4-4750812f5c3d.mov


