### PR TITLE
Allow the user to print an access kit containing the private key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "@useful-tools/localstorage": "^1.2.0",
                 "capacitor-native-biometric": "^3.1.1",
                 "firebase": "^9.8.3",
+                "html5-qrcode": "^2.3.8",
                 "i18next": "^21.8.10",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -9026,6 +9027,11 @@
             "peerDependencies": {
                 "webpack": "^5.20.0"
             }
+        },
+        "node_modules/html5-qrcode": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+            "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ=="
         },
         "node_modules/htmlparser2": {
             "version": "6.1.0",
@@ -23561,6 +23567,11 @@
                 "pretty-error": "^4.0.0",
                 "tapable": "^2.0.0"
             }
+        },
+        "html5-qrcode": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+            "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ=="
         },
         "htmlparser2": {
             "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "passager-password-manager",
-    "version": "0.1.0",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "passager-password-manager",
-            "version": "0.1.0",
+            "version": "1.1.0",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@capacitor-community/http": "^1.4.1",
@@ -19,7 +19,6 @@
                 "@capacitor/status-bar": "^1.0.8",
                 "@mdi/js": "^6.7.96",
                 "@mdi/react": "^1.6.0",
-                "@objekt/capacitor-app-updater": "^1.0.3",
                 "@testing-library/jest-dom": "^5.16.4",
                 "@testing-library/react": "^13.3.0",
                 "@testing-library/user-event": "^14.2.1",
@@ -31,6 +30,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-i18next": "^11.17.2",
+                "react-qr-code": "^2.0.11",
                 "react-router-dom": "^6.3.0",
                 "react-scripts": "5.0.1",
                 "styled-components": "^5.3.5",
@@ -3443,19 +3443,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@objekt/capacitor-app-updater": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@objekt/capacitor-app-updater/-/capacitor-app-updater-1.0.3.tgz",
-            "integrity": "sha512-Y+IqjJ9R/eOwpRmg55/EEHlbl8rzr6268E0LEGbs5lQBBYm6n3mqUPPNaBXFJksPXTOe9OLLX8Bcb2/6GYaUMA==",
-            "dependencies": {
-                "@capacitor-community/http": "^1.4.1",
-                "@capacitor/core": "^3.5.1",
-                "@capacitor/filesystem": "^1.1.0"
-            },
-            "engines": {
-                "node": "16.x"
             }
         },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -13724,6 +13711,11 @@
                 "teleport": ">=0.2.0"
             }
         },
+        "node_modules/qr.js": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+            "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+        },
         "node_modules/qs": {
             "version": "6.10.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -13968,6 +13960,24 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        },
+        "node_modules/react-qr-code": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.11.tgz",
+            "integrity": "sha512-P7mvVM5vk9NjGdHMt4Z0KWeeJYwRAtonHTghZT2r+AASinLUUKQ9wfsGH2lPKsT++gps7hXmaiMGRvwTDEL9OA==",
+            "dependencies": {
+                "prop-types": "^15.8.1",
+                "qr.js": "0.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.x || ^17.x || ^18.x",
+                "react-native-svg": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-svg": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/react-refresh": {
             "version": "0.11.0",
@@ -19444,16 +19454,6 @@
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
-            }
-        },
-        "@objekt/capacitor-app-updater": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@objekt/capacitor-app-updater/-/capacitor-app-updater-1.0.3.tgz",
-            "integrity": "sha512-Y+IqjJ9R/eOwpRmg55/EEHlbl8rzr6268E0LEGbs5lQBBYm6n3mqUPPNaBXFJksPXTOe9OLLX8Bcb2/6GYaUMA==",
-            "requires": {
-                "@capacitor-community/http": "^1.4.1",
-                "@capacitor/core": "^3.5.1",
-                "@capacitor/filesystem": "^1.1.0"
             }
         },
         "@pmmmwh/react-refresh-webpack-plugin": {
@@ -26787,6 +26787,11 @@
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
         },
+        "qr.js": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+            "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+        },
         "qs": {
             "version": "6.10.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -26961,6 +26966,15 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
             "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        },
+        "react-qr-code": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.11.tgz",
+            "integrity": "sha512-P7mvVM5vk9NjGdHMt4Z0KWeeJYwRAtonHTghZT2r+AASinLUUKQ9wfsGH2lPKsT++gps7hXmaiMGRvwTDEL9OA==",
+            "requires": {
+                "prop-types": "^15.8.1",
+                "qr.js": "0.0.0"
+            }
         },
         "react-refresh": {
             "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^11.17.2",
+        "react-qr-code": "^2.0.11",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@useful-tools/localstorage": "^1.2.0",
         "capacitor-native-biometric": "^3.1.1",
         "firebase": "^9.8.3",
+        "html5-qrcode": "^2.3.8",
         "i18next": "^21.8.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
         "@useful-tools/localstorage": "^1.2.0",
         "capacitor-native-biometric": "^3.1.1",
         "firebase": "^9.8.3",
-        "html5-qrcode": "^2.3.8",
         "i18next": "^21.8.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/components/atoms/TextArea/index.js
+++ b/src/components/atoms/TextArea/index.js
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Passager Password Manager.
+ * https://github.com/oegea/passager-password-manager
+ *
+ * Copyright (C) 2022 Oriol Egea Carvajal
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Third party dependencies
+import styled from 'styled-components';
+
+const TextArea = styled.textarea`
+    border: 1px solid black;
+    border-radius: 5px;
+    font-size: 16px;
+    height: 100px;
+    padding: 5px;
+    width: 100%;
+
+    &::placeholder {
+        font-size: 16px;
+    }
+`;
+const AtomTextArea = (props) => {
+    return <TextArea {...props} />;
+};
+
+AtomTextArea.displayName = 'AtomTextArea';
+
+export default AtomTextArea;

--- a/src/components/organisms/UserDetailsRightPanel/index.js
+++ b/src/components/organisms/UserDetailsRightPanel/index.js
@@ -28,6 +28,7 @@ import useTranslation from '../../../hooks/useTranslation/index.js';
 import withUser from '../../../providers/WithUser.js';
 // Libs
 import {isBackendMode} from '../../../libs/backend.js';
+import {createExportableFragment} from '../../../libs/privateKey.js';
 // Vendor
 import QRCode from 'react-qr-code';
 import {printElementById} from '../../../vendor/print.js';
@@ -90,7 +91,7 @@ const UserDetailsRightPanel = ({ user }) => {
                             This is the access kit for <strong>{user.email || '-'}</strong>.
                         </p>
                         <p>
-                            You will need to provide your user private key the first time you login on a new device. Please store this access kit on a safe place.
+                            You will need your user private key when logging in on a new device. Store this document on a safe place.
                         </p>
                         <p>
                             <strong>QR codes:</strong>
@@ -99,18 +100,28 @@ const UserDetailsRightPanel = ({ user }) => {
                             When accessing from a mobile phone, you can scan the following QR codes to provide your private key. Please scan them in the same order as they appear below (from left to right).
                         </p>
                         <div style={{border: '5px dashed #ccc', display: 'flex', justifyContent: 'space-around', padding: '20px'}}>
-                            <QRCode value={user.encryptedPrivateKey.slice(0, user.encryptedPrivateKey.length / 2)} />
+                            <QRCode value={createExportableFragment({
+                                content: user.encryptedPrivateKey, 
+                                ownerIdentifier: user.email, 
+                                totalFragments: 2, 
+                                fragmentNumber: 1
+                            })} />
 
-                            <QRCode value={user.encryptedPrivateKey.slice(user.encryptedPrivateKey.length / 2)} />
+                            <QRCode value={createExportableFragment({
+                                content: user.encryptedPrivateKey, 
+                                ownerIdentifier: user.email, 
+                                totalFragments: 2, 
+                                fragmentNumber: 2
+                            })} />
                         </div>
 
                         <p>
                             <strong>Private key:</strong>
                         </p>
                         <p>
-                            If accessing Passager from a computer, you can directly copy and paste the following text:
+                            If you prefer to not print this file, you can directly copy and paste the following text:
                         </p>
-                        <p style={{wordBreak: 'break-all', border: '5px dashed #ccc', padding: '20px'}}>
+                        <p style={{wordBreak: 'break-all', border: '5px dashed #ccc', padding: '20px', fontSize: '5px'}}>
                             {user.encryptedPrivateKey}
                         </p>
 
@@ -118,7 +129,7 @@ const UserDetailsRightPanel = ({ user }) => {
                             <strong>Master password:</strong>
                         </p>
                         <p>
-                            It is recommended to remember the master password and not to write it down anywhere. However, in case you need to write it down to ensure that you do not lose access to your account, you can use the following space once you have printed this access kit.
+                            It is recommended to remember the master password and not writting it down anywhere. However, in case you feel more comfortable writting it down, you can do it here:
                         </p>
 
                         <div style={{border: '5px dashed #ccc', padding: '50px'}}>

--- a/src/components/organisms/UserDetailsRightPanel/index.js
+++ b/src/components/organisms/UserDetailsRightPanel/index.js
@@ -26,6 +26,11 @@ import SectionTitle from '../../molecules/SectionTitle/index.js';
 import useTranslation from '../../../hooks/useTranslation/index.js';
 // Context
 import withUser from '../../../providers/WithUser.js';
+// Libs
+import {isBackendMode} from '../../../libs/backend.js';
+// Vendor
+import QRCode from 'react-qr-code';
+import {printElementById} from '../../../vendor/print.js';
 
 const UserDetailsRightPanel = ({ user }) => {
     const { t } = useTranslation();
@@ -34,19 +39,94 @@ const UserDetailsRightPanel = ({ user }) => {
             <SectionTitle title={t('profile.User details')} buttons={[]} />
 
             <p>
-                <strong>{t('profile.Name')}: </strong>
-                {user.displayName || '-'}
-            </p>
-
-            <p>
                 <strong>{t('profile.Email')}: </strong>
                 {user.email || '-'}
             </p>
 
-            <p>
-                <strong>{t('profile.Id')}: </strong>
-                {user.uid || '-'}
-            </p>
+
+            {!isBackendMode() && 
+                <>
+                    <SectionTitle title={'Increased security mode'} buttons={[]} />
+                    <p>
+                        Passager encrypts all your data before sending it to your organization servers (this include passwords, and any other sensible data you store in Passager). By doing this, you can be sure that only you and the people with whom you may have shared your folders, can have access to your data.
+                    </p>
+                    <p>
+                        In order to achieve this high security level, Passager relies in two main components:
+                    </p>
+                    <ol>
+                        <li>
+                            The first one, is your user encryption key (also referred as &quot;private key&quot;). This key is randomly generated when you login for the first time, and it is the unique key that can decrypt your data. By default this key is managed by Passager, and is stored in your organization servers.
+                        </li>
+                        <li>
+                            The second one, is your master password. It&apos;s a password you choose when you login for the first time, and it is used to encrypt your private key in order to ensure that nobody from your organization or any hypothetical attacker can read your private key, which will enable them to decrypt your information.
+                        </li>
+                    </ol>
+                    <p>
+                        This system guarantees the safety of your data, as long as your master password is strong-enough.
+                    </p>
+                    <p>
+                        However, in case an additional level of security is required, you can opt to manage your user private key by yourself. This means that, once you enable this mode, your private key will no-longer be stored by your organization, and you will be in charge of storing it in a safe place.
+                    </p>
+                    <p>
+                        As Passager needs your private key to work, you will need to provide it the first time you login on a new device. After logging in, your private key will be stored in your device and you will not be asked for it again unless you remove Passager&apos;s data, or you login on a new device.
+                    </p>
+                    <p>
+                        Please note, the same way as your master password, you will not be able to recover your private key if you lose it. So, please, make sure you store it in a safe place <strong>or you can lose access to your data forever</strong>.
+                    </p>
+                    <p>
+                        To help you store your private key, once you enable the advanced security mode, Passager will allow you to download and print an access kit, which will contain your private key splitted in two QR codes that you will be able to directly scan with your phone when you need to login on a new device.
+                    </p>
+                </>
+            }
+
+            {isBackendMode() && 
+                <div>
+                    <SectionTitle title={'Passager Access Kit'} buttons={[{
+                        label: 'Print',
+                        onClick: () => printElementById('access-kit', 'Passager Access Kit'),
+                    }]}/> 
+                    <div id="access-kit">
+                        <p>
+                            This is the access kit for <strong>{user.email || '-'}</strong>.
+                        </p>
+                        <p>
+                            You will need to provide your user private key the first time you login on a new device. Please store this access kit on a safe place.
+                        </p>
+                        <p>
+                            <strong>QR codes:</strong>
+                        </p>
+                        <p>
+                            When accessing from a mobile phone, you can scan the following QR codes to provide your private key. Please scan them in the same order as they appear below (from left to right).
+                        </p>
+                        <div style={{border: '5px dashed #ccc', display: 'flex', justifyContent: 'space-around', padding: '20px'}}>
+                            <QRCode value={user.encryptedPrivateKey.slice(0, user.encryptedPrivateKey.length / 2)} />
+
+                            <QRCode value={user.encryptedPrivateKey.slice(user.encryptedPrivateKey.length / 2)} />
+                        </div>
+
+                        <p>
+                            <strong>Private key:</strong>
+                        </p>
+                        <p>
+                            If accessing Passager from a computer, you can directly copy and paste the following text:
+                        </p>
+                        <p style={{wordBreak: 'break-all', border: '5px dashed #ccc', padding: '20px'}}>
+                            {user.encryptedPrivateKey}
+                        </p>
+
+                        <p>
+                            <strong>Master password:</strong>
+                        </p>
+                        <p>
+                            It is recommended to remember the master password and not to write it down anywhere. However, in case you need to write it down to ensure that you do not lose access to your account, you can use the following space once you have printed this access kit.
+                        </p>
+
+                        <div style={{border: '5px dashed #ccc', padding: '50px'}}>
+                            
+                        </div>
+                    </div>
+                </div>
+            }
         </>
     );
 };

--- a/src/components/pages/UserPrivateKeyValidation/index.js
+++ b/src/components/pages/UserPrivateKeyValidation/index.js
@@ -1,0 +1,157 @@
+/**
+ * This file is part of Passager Password Manager.
+ * https://github.com/oegea/passager-password-manager
+ *
+ * Copyright (C) 2022 Oriol Egea Carvajal
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Third party dependencies
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import PropTypes from 'prop-types';
+import useTranslation from '../../../hooks/useTranslation/index.js';
+// Own libs
+import { logout } from '../../../libs/auth.js';
+import { isMobileDevice } from '../../../libs/mobile.js';
+// Atoms
+import Title from '../../atoms/Title/index.js';
+import Button from '../../atoms/Button/index.js';
+import AtomButtonLink from '../../atoms/ButtonLink/index.js';
+import ButtonWrapper from '../../atoms/Dialog/DialogButtonWrapper.js';
+import Input from '../../atoms/Input/index.js';
+import InputWrapper from '../../atoms/Dialog/DialogInputWrapper.js';
+import InputLabel from '../../atoms/InputLabel/index.js';
+// Molecules
+import GlobalSpinner from '../../molecules/GlobalSpinner/index.js';
+// Templates
+import NotLogged from '../../templates/NotLogged/index.js';
+// Context
+import withUser from '../../../providers/WithUser.js';
+// Hooks
+import useDialogConfirmation from '../../../hooks/useDialogConfirmation/index.js';
+import LanguageSelector from '../../molecules/LanguageSelector/index.js';
+// Vendor
+import {Html5QrcodeScanner} from 'html5-qrcode';
+
+const PageUserPrivateKeyValidation = ({ user }) => {
+    const { t } = useTranslation();
+    const [password, setPassword] = useState({
+        value: '',
+        error: '',
+    });
+    const qrScanner = useRef(null);
+
+    const [displaySpinner, setDisplaySpinner] = useState(false);
+
+    const onLogin = useCallback(
+        async (overridedPassword) => {
+            if (overridedPassword) password.value = overridedPassword;
+
+            if (displaySpinner) {
+                return;
+            }
+            setDisplaySpinner(true);
+            const decryptResult = await user.decryptPrivateKey(password.value);
+            let error = '';
+
+            if (decryptResult === false) {
+                error = t(
+                    'userMasterPasswordValidation.The entered password is not valid'
+                );
+            }
+
+            setDisplaySpinner(false);
+            setPassword({
+                value: password.value,
+                error,
+            });
+        },
+        [displaySpinner, password, t, user]
+    );
+
+    const onScanSuccess = (decodedText, decodedResult) => {
+        // Handle on success condition with the decoded text or result.
+        console.log(`Scan result: ${decodedText}`, decodedResult);
+        setPassword({ value: password.value+decodedText, error: '' });
+    };
+
+    useEffect(() => {
+        qrScanner.current = new Html5QrcodeScanner(
+            'reader', { fps: 10, qrbox: 250 });
+        qrScanner.current.render(onScanSuccess);
+    });
+
+    useDialogConfirmation(() => null, onLogin);
+
+    return (
+        <>
+            <NotLogged>
+                {displaySpinner && <GlobalSpinner />}
+                <Title>
+                    Please provide your private key to continue
+                </Title>
+
+                <p>
+                    You need to provide your private key the first time you login on a new device.
+                </p>
+                <p>
+                    Please copy it manually, or by scanning it from the two QR codes from your access kit.
+                </p>
+                <div id="reader"></div>
+                <InputWrapper marginBottom="25px">
+                    <InputLabel htmlFor="password">
+                        Private key
+                    </InputLabel>
+                    <Input
+                        defaultValue={password.value}
+                        id="password"
+                        type="password"
+                        placeholder={t(
+                            'userMasterPasswordValidation.Type here your private key'
+                        )}
+                        onChange={(e) =>
+                            setPassword({ value: e.target.value, error: '' })
+                        }
+                    />
+                    {password.error.length > 0 && (
+                        <span style={{ color: 'red' }}>{password.error}</span>
+                    )}
+                </InputWrapper>
+                <ButtonWrapper justifyContent="center">
+                    <Button
+                        label={t('common.Access')}
+                        onClick={() => onLogin()}
+                    />
+                </ButtonWrapper>
+
+                {
+                    !isMobileDevice() && 
+                    <AtomButtonLink onClick={logout}>
+                        {t('common.Logout')}
+                    </AtomButtonLink>
+                }
+                <LanguageSelector />
+            </NotLogged>
+        </>
+    );
+};
+
+PageUserPrivateKeyValidation.displayName =
+    'PageUserPrivateKeyValidation';
+PageUserPrivateKeyValidation.propTypes = {
+    user: PropTypes.object,
+};
+
+export default withUser(PageUserPrivateKeyValidation);

--- a/src/components/pages/UserPrivateKeyValidation/index.js
+++ b/src/components/pages/UserPrivateKeyValidation/index.js
@@ -81,16 +81,17 @@ const PageUserPrivateKeyValidation = ({ user }) => {
             return;
         }
 
-        if (fragment.totalFragments === qrCodes.length + 1) {
-            storePrivateKey(qrCodes.join(''), user.email);
-            return;
-        }
-
-        setQrCodes([...qrCodes, fragment.fragmentContent]);
+        const newQrCodesValue = [...qrCodes, fragment.fragmentContent];
+        setQrCodes(newQrCodesValue);
         setCurrentQRContent({
             value: '',
             error: '',
         });
+
+        if (fragment.totalFragments === qrCodes.length + 1) {
+            storePrivateKey(newQrCodesValue.join(''), user.email);
+            return;
+        }
     };
 
     const textInputMode = (

--- a/src/domain/index.js
+++ b/src/domain/index.js
@@ -63,6 +63,8 @@ const useCases = {
     users: {
         update_user_public_key_use_case:
             UsersUseCasesFactory.updateUserPublicKeyUseCase({ config }),
+        update_user_private_key_use_case:
+            UsersUseCasesFactory.updateUserPrivateKeyUseCase({ config }),
         get_user_public_key_use_case:
             UsersUseCasesFactory.getUserPublicKeyUseCase({ config }),
         get_and_create_user_document_use_case:

--- a/src/domain/users/Repositories/BackendUsersRepository.js
+++ b/src/domain/users/Repositories/BackendUsersRepository.js
@@ -72,6 +72,20 @@ export default class BackendUsersRepository extends UsersRepository {
         });
     }
 
+    async updateUserPrivateKey({ userOperationRequest }) {
+        // Retrieve data
+        const uid = userOperationRequest.getUid();
+        const privateKey = userOperationRequest.getPrivateKey();
+
+        const document = {
+            privateKey
+        };
+
+        await setDocument('users', document, {
+            email: uid
+        });
+    }
+
     async getUserDocumentByUid({ userOperationRequest }) {
         // Retrieve uid
         const uid = userOperationRequest.getUid();

--- a/src/domain/users/Repositories/FirebaseUsersRepository.js
+++ b/src/domain/users/Repositories/FirebaseUsersRepository.js
@@ -27,6 +27,10 @@ export default class FirebaseUsersRepository extends UsersRepository {
         this._firebaseUtils = firebaseUtils;
     }
 
+    async updateUserPrivateKey() {
+        throw new Error('Not implemented');
+    }
+
     async getUserPublicDetails({ userOperationRequest }) {
         const email = userOperationRequest.getEmail();
 

--- a/src/domain/users/Repositories/LocalUsersRepository.js
+++ b/src/domain/users/Repositories/LocalUsersRepository.js
@@ -72,6 +72,26 @@ export default class LocalUsersRepository extends UsersRepository {
         );
     }
 
+    async updateUserPrivateKey({ userOperationRequest }) {
+        // Retrieve data
+        const uid = userOperationRequest.getUid();
+        const privateKey = userOperationRequest.getPrivateKey();
+        const email = userOperationRequest.getEmail();
+
+        const document = {
+            uid,
+            privateKey,
+            email,
+        };
+
+        this._LocalStorageDatabase.setDocument(
+            'userSharingSettings',
+            document,
+            'uid',
+            uid
+        );
+    }
+
     async getUserDocumentByUid({ userOperationRequest }) {
         // Retrieve uid
         const uid = userOperationRequest.getUid();

--- a/src/domain/users/Repositories/UsersRepository.js
+++ b/src/domain/users/Repositories/UsersRepository.js
@@ -38,6 +38,15 @@ export default class UsersRepository {
     }
 
     /**
+     * Updates private key of a user
+     */
+    async updateUserPrivateKey() {
+        throw new Error(
+            '[UsersRepository][updateUserPrivateKey] is not implemented yet'
+        );
+    }
+
+    /**
      * Gets the user document by uid
      */
     async getUserDocumentByUid() {

--- a/src/domain/users/Requests/UserOperationRequest.js
+++ b/src/domain/users/Requests/UserOperationRequest.js
@@ -25,6 +25,7 @@ export class UserOperationRequest {
         password = '',
         photoURL = '',
         publicKey = '',
+        privateKey = '',
         uid = '',
     }) {
         this._displayName = displayName;
@@ -32,6 +33,7 @@ export class UserOperationRequest {
         this._password = password;
         this._photoURL = photoURL;
         this._publicKey = publicKey;
+        this._privateKey = privateKey;
         this._uid = uid;
     }
 
@@ -57,6 +59,10 @@ export class UserOperationRequest {
 
     setPublicKey(publicKey) {
         this._publicKey = publicKey;
+    }
+
+    getPrivateKey() {
+        return this._privateKey;
     }
 
     getUid() {

--- a/src/domain/users/Services/UpdateUserPrivateKeyService.js
+++ b/src/domain/users/Services/UpdateUserPrivateKeyService.js
@@ -18,31 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { UserOperationRequest } from './UserOperationRequest.js';
-import { UserSubscriptionRequest } from './UserSubscriptionRequest.js';
+export class UpdateUserPrivateKeyService {
+    constructor({ repository }) {
+        this._repository = repository;
+    }
 
-export class UsersRequestsFactory {
-    static userOperationRequest = ({
-        displayName,
-        email,
-        password,
-        photoURL,
-        publicKey,
-        privateKey,
-        uid,
-    }) => {
-        return new UserOperationRequest({
-            displayName,
-            email,
-            password,
-            photoURL,
-            publicKey,
-            privateKey,
-            uid,
+    async execute({ userOperationRequest }) {
+        await this._repository.updateUserPrivateKey({
+            userOperationRequest,
         });
-    };
-
-    static userSubscriptionRequest = ({ onSubscriptionChanges }) => {
-        return new UserSubscriptionRequest({ onSubscriptionChanges });
-    };
+    }
 }

--- a/src/domain/users/Services/factory.js
+++ b/src/domain/users/Services/factory.js
@@ -28,6 +28,7 @@ import { GetAndCreateUserDocumentService } from './GetAndCreateUserDocumentServi
 import { UpdateUserDocumentService } from './UpdateUserDocumentService.js';
 import { SetUserMasterPasswordService } from './SetUserMasterPasswordService.js';
 import { SubscribeToAuthStateChangeService } from './SubscribeToAuthStateChangeService.js';
+import { UpdateUserPrivateKeyService } from './UpdateUserPrivateKeyService.js';
 // Factories
 import { UsersRepositoriesFactory } from '../Repositories/factory.js';
 import { UsersEntitiesFactory } from '../Entities/factory.js';
@@ -45,6 +46,11 @@ export class UsersServicesFactory {
 
     static updateUserPublicKeyService = ({ config }) =>
         new UpdateUserPublicKeyService({
+            repository: UsersRepositoriesFactory.getRepository({ config }),
+        });
+
+    static updateUserPrivateKeyService = ({ config }) =>
+        new UpdateUserPrivateKeyService({
             repository: UsersRepositoriesFactory.getRepository({ config }),
         });
 

--- a/src/domain/users/UseCases/UpdateUserPrivateKeyUseCase.js
+++ b/src/domain/users/UseCases/UpdateUserPrivateKeyUseCase.js
@@ -18,31 +18,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { UserOperationRequest } from './UserOperationRequest.js';
-import { UserSubscriptionRequest } from './UserSubscriptionRequest.js';
+export class UpdateUserPrivateKeyUseCase {
+    constructor({ service, userOperationRequest }) {
+        this._service = service;
+        this._userOperationRequest = userOperationRequest;
+    }
 
-export class UsersRequestsFactory {
-    static userOperationRequest = ({
-        displayName,
-        email,
-        password,
-        photoURL,
-        publicKey,
-        privateKey,
-        uid,
-    }) => {
-        return new UserOperationRequest({
-            displayName,
+    async execute({ email, privateKey, uid }) {
+        const userOperationRequest = this._userOperationRequest({
             email,
-            password,
-            photoURL,
-            publicKey,
             privateKey,
             uid,
         });
-    };
-
-    static userSubscriptionRequest = ({ onSubscriptionChanges }) => {
-        return new UserSubscriptionRequest({ onSubscriptionChanges });
-    };
+        await this._service.execute({ userOperationRequest });
+    }
 }

--- a/src/domain/users/UseCases/factory.js
+++ b/src/domain/users/UseCases/factory.js
@@ -27,11 +27,20 @@ import { GetUserPublicKeyUseCase } from './GetUserPublicKeyUseCase.js';
 import { GetAndCreateUserDocumentUseCase } from './/GetAndCreateUserDocumentUseCase.js';
 import { SetUserMasterPasswordUseCase } from './SetUserMasterPasswordUseCase.js';
 import { SubscribeToAuthStateChangeUseCase } from './SubscribeToAuthStateChangeUseCase.js';
+import { UpdateUserPrivateKeyUseCase } from './UpdateUserPrivateKeyUseCase.js';
 
 export class UsersUseCasesFactory {
     static updateUserPublicKeyUseCase = ({ config }) =>
         new UpdateUserPublicKeyUseCase({
             service: UsersServicesFactory.updateUserPublicKeyService({
+                config,
+            }),
+            userOperationRequest: UsersRequestsFactory.userOperationRequest,
+        });
+
+    static updateUserPrivateKeyUseCase = ({ config }) =>
+        new UpdateUserPrivateKeyUseCase({
+            service: UsersServicesFactory.updateUserPrivateKeyService({
                 config,
             }),
             userOperationRequest: UsersRequestsFactory.userOperationRequest,

--- a/src/libs/auth.js
+++ b/src/libs/auth.js
@@ -32,6 +32,7 @@ export const logout = () => {
     localStorage.setItem('storeMode', 'FIREBASE');
 
     localStorage.removeItem('jwtToken');
+    localStorage.removeItem('privateUserKey');
     window.location.href = '/';
 };
 

--- a/src/libs/backend.js
+++ b/src/libs/backend.js
@@ -110,7 +110,9 @@ export const setDocument = async (collection, document, findCriteria) => {
         const existingDocument = searchResult[0];
 
         const updatedDocument = {
-            ...document
+            ...existingDocument,
+            ...document,
+            id: undefined
         };
 
         const result = await updateDocument(

--- a/src/libs/mobile.js
+++ b/src/libs/mobile.js
@@ -8,7 +8,7 @@ import { Share } from '@capacitor/share';
 export const initMobileSettings = async () => {
     StatusBar.hide();
     // Check for app updates - only if the app has not been launched in the last 60 minutes. 
-    const didUpdate = await AppUpdater.sync('https://passager-password-manager-git-feat-private-key-loc-12f65a-oegea.vercel.app', 1000*60*60);
+    const didUpdate = await AppUpdater.sync('https://cloud.passager.app', 1000*60*60);
 
     return didUpdate;
 };

--- a/src/libs/mobile.js
+++ b/src/libs/mobile.js
@@ -8,7 +8,7 @@ import { Share } from '@capacitor/share';
 export const initMobileSettings = async () => {
     StatusBar.hide();
     // Check for app updates - only if the app has not been launched in the last 60 minutes. 
-    const didUpdate = await AppUpdater.sync('https://cloud.passager.app', 1000*60*60);
+    const didUpdate = await AppUpdater.sync('https://passager-password-manager-git-feat-private-key-loc-12f65a-oegea.vercel.app', 1000*60*60);
 
     return didUpdate;
 };

--- a/src/libs/privateKey.js
+++ b/src/libs/privateKey.js
@@ -1,0 +1,63 @@
+export const createFragment = ({content, ownerIdentifier, totalFragments, fragmentNumber}) => {
+    // Calculate length of each fragment
+    const fragmentLength = Math.ceil(content.length / totalFragments);
+    // Calculate the latest fragment finish
+    const lastFragmentFinish = (fragmentNumber - 1) * fragmentLength;
+    // Get the desired fragment
+    const fragmentContent = content.slice(lastFragmentFinish, lastFragmentFinish + fragmentLength);
+    // Create the fragment
+    return {
+        ownerIdentifier,
+        totalFragments,
+        fragmentNumber,
+        fragmentContent
+    };
+};
+
+export const createExportableFragment = ({content, ownerIdentifier, totalFragments, fragmentNumber}) => {
+    return JSON.stringify(createFragment({content, ownerIdentifier, totalFragments, fragmentNumber}));
+};
+
+export const readPrivateKeyFromLocalStorage = (currentUser) => {
+    try {
+        const storedUserKey = JSON.parse(localStorage.getItem('privateUserKey'));
+
+        if (storedUserKey === null || storedUserKey.owner !== currentUser.email) {
+            return null;
+        } else {
+            return storedUserKey.privateKey;
+        }
+    } catch (error) {
+        console.error(error);
+        return null;
+    }
+};
+
+export const storePrivateKey = (privateKey, userEmail) => {
+
+    try{
+        const privateKeyObject = {
+            owner: userEmail,
+            privateKey
+        };
+
+        localStorage.setItem('privateUserKey', JSON.stringify(privateKeyObject));
+
+        document.location.reload();
+        return true;
+
+    }
+    catch(error){
+        console.error(error);
+        return false;
+    }
+};
+
+export const getPrivateKeyFragment = (fragment) => {
+    try {
+        return JSON.parse(fragment);
+    } catch( error ) {
+        console.error(error);
+        return null;
+    }
+};

--- a/src/providers/UserProvider.js
+++ b/src/providers/UserProvider.js
@@ -53,9 +53,12 @@ class UserProvider extends Component {
             }
 
             // TODO: Always reading from localStorage for testing purposes
-            //if (userDocument.privateKey === null) 
-            if (localStorage.getItem('storeMode') === 'BACKEND')
+            if (userDocument.privateKey.length === 0) {
+                userDocument.isPrivateKeyStoredLocally = true;
                 userDocument.privateKey = readPrivateKeyFromLocalStorage(userDocument);
+            } else {
+                userDocument.isPrivateKeyStoredLocally = false;
+            }
 
             await this.asyncSetState({ user: userDocument });
         };

--- a/src/providers/UserProvider.js
+++ b/src/providers/UserProvider.js
@@ -52,7 +52,6 @@ class UserProvider extends Component {
                     this.onSubscriptionChanges.bind(this, user);
             }
 
-            // TODO: Always reading from localStorage for testing purposes
             if (userDocument.privateKey.length === 0) {
                 userDocument.isPrivateKeyStoredLocally = true;
                 userDocument.privateKey = readPrivateKeyFromLocalStorage(userDocument);

--- a/src/providers/UserProvider.js
+++ b/src/providers/UserProvider.js
@@ -24,6 +24,8 @@ import { importRSAKeyPair } from '@useful-tools/crypto';
 
 // Domain
 import domain from '../domain/index.js';
+// Libs
+import {readPrivateKeyFromLocalStorage} from '../libs/privateKey.js';
 
 export const UserContext = createContext();
 
@@ -49,7 +51,12 @@ class UserProvider extends Component {
                 userDocument.reloadAuthDetails =
                     this.onSubscriptionChanges.bind(this, user);
             }
-            userDocument.privateKey = null; // Temp change to test local stored private keys
+
+            // TODO: Always reading from localStorage for testing purposes
+            //if (userDocument.privateKey === null) 
+            if (localStorage.getItem('storeMode') === 'BACKEND')
+                userDocument.privateKey = readPrivateKeyFromLocalStorage(userDocument);
+
             await this.asyncSetState({ user: userDocument });
         };
 

--- a/src/providers/UserProvider.js
+++ b/src/providers/UserProvider.js
@@ -49,7 +49,7 @@ class UserProvider extends Component {
                 userDocument.reloadAuthDetails =
                     this.onSubscriptionChanges.bind(this, user);
             }
-
+            userDocument.privateKey = null; // Temp change to test local stored private keys
             await this.asyncSetState({ user: userDocument });
         };
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -30,6 +30,7 @@ import Profile from './components/pages/Profile/index.js';
 import ProfileBackups from './components/pages/Profile/backups.js';
 import UserMasterPasswordValidation from './components/pages/UserMasterPasswordValidation/index.js';
 import UserSignup from './components/pages/UserSignup/index.js';
+import UserPrivateKeyValidation from './components/pages/UserPrivateKeyValidation/index.js';
 import Privacy from './components/pages/Privacy/index.js';
 // Context
 import withUser from './providers/WithUser.js';
@@ -39,11 +40,24 @@ const RoutesConfiguration = ({ user }) => {
         <BrowserRouter>
             {user !== null &&
                 user.initialized === true &&
-                user.decryptedPrivateKey === false && (
+                user.decryptedPrivateKey === false && 
+                user.privateKey !== null && (
                 <Routes>
                     <Route
                         path="*"
                         element={<UserMasterPasswordValidation />}
+                    />
+                </Routes>
+            )}
+
+            {user !== null &&
+                user.initialized === true &&
+                user.decryptedPrivateKey === false &&
+                user.privateKey === null && (
+                <Routes>
+                    <Route
+                        path="*"
+                        element={<UserPrivateKeyValidation />}
                     />
                 </Routes>
             )}

--- a/src/vendor/print.js
+++ b/src/vendor/print.js
@@ -1,0 +1,18 @@
+export const printElementById = (element, title) =>
+{
+    var mywindow = window.open('', 'PRINT', 'height=400,width=600');
+
+    mywindow.document.write('<html><head><title>' + document.title  + '</title>');
+    mywindow.document.write('</head><body >');
+    mywindow.document.write('<h1>' + title  + '</h1>');
+    mywindow.document.write(document.getElementById(element).innerHTML);
+    mywindow.document.write('</body></html>');
+
+    mywindow.document.close(); // necessary for IE >= 10
+    mywindow.focus(); // necessary for IE >= 10*/
+
+    mywindow.print();
+    mywindow.close();
+
+    return true;
+};


### PR DESCRIPTION
# Pull Request

## 💬 Context

We are adding an enhanced security mode to Passager, in order to allow users to self-store their own private keys when using Passager on the cloud with their organization servers.

## 👩🏼‍🎨 Changes

This PR start making changes in order to create this new mode, and provide users with features to download and print an access kit to safely store their private key.
